### PR TITLE
Various fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,21 @@
+# Python package build files
+build
+dist
+*.egg-info
+
+# IPython/Jupyter notebook checkpoints
+.ipynb_checkpoints
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Sphinx documentation build files
+docs/_build/
+
+# Mac auxillary files
+.DS_Store

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,6 +13,5 @@ sphinx:
 conda:
    environment: docs/environment.yaml
 
-python:
-  version: 3.8
-
+build:
+  os: ubuntu-22.04

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,3 +15,5 @@ conda:
 
 build:
   os: ubuntu-22.04
+  tools:
+    python: "miniconda-latest"

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@
 
 Under the main directory, install the package with:
 ```
-python setup.py install --user
+python3 -m pip install --user .
 ```
 You can also install it in developer mode, so that any changes you make to the code take place immediately:
 ```
-python setup.py develop --user
+python3 -m pip install --user -e .
 ```
 
 ### Documentation

--- a/densitysplit/pipeline.py
+++ b/densitysplit/pipeline.py
@@ -114,7 +114,7 @@ class DensitySplit:
 
     def get_density_mesh(self, smooth_radius, cellsize, compensate=False,
         resampler='cic', interlacing=0, sampling='randoms', sampling_positions=None,
-        boxpad=2.0, filter_shape='Tophat', ran_min=0.01):
+        boxpad=2.0, filter_shape='TopHat', ran_min=0.01):
         """
         Get the overdensity field.
 

--- a/docs/environment.yaml
+++ b/docs/environment.yaml
@@ -10,3 +10,4 @@ dependencies:
 - scipy
 - pandas
 - astropy
+- sphinx_rtd_theme

--- a/docs/environment.yaml
+++ b/docs/environment.yaml
@@ -8,6 +8,7 @@ dependencies:
 - python=3.8
 - numpy
 - scipy
+- matplotlib
 - pandas
 - astropy
 - sphinx_rtd_theme

--- a/nb/examples.ipynb
+++ b/nb/examples.ipynb
@@ -66,7 +66,7 @@
     "\n",
     "ds = DensitySplit(data_positions=data_positions, boxsize=boxsize)\n",
     "\n",
-    "density = ds.get_density(smooth_radius=smooth_radius, cellsize=cellsize, sampling='randoms')"
+    "density = ds.get_density_mesh(smooth_radius=smooth_radius, cellsize=cellsize, sampling='randoms')"
    ]
   },
   {
@@ -219,7 +219,7 @@
     "\n",
     "ds = DensitySplit(data_positions=data_positions, randoms_positions=randoms_positions)\n",
     "\n",
-    "density_wrand = ds.get_density(smooth_radius=smooth_radius, cellsize=cellsize,\n",
+    "density_wrand = ds.get_density_mesh(smooth_radius=smooth_radius, cellsize=cellsize,\n",
     "    sampling='randoms')"
    ]
   },
@@ -288,8 +288,8 @@
    "source": [
     "ds = DensitySplit(data_positions=data_positions, boxsize=boxsize)\n",
     "\n",
-    "density_data = ds.get_density(smooth_radius=smooth_radius, cellsize=cellsize, sampling='data')\n",
-    "density_randoms = ds.get_density(smooth_radius=smooth_radius, cellsize=cellsize, sampling='randoms')\n",
+    "density_data = ds.get_density_mesh(smooth_radius=smooth_radius, cellsize=cellsize, sampling='data')\n",
+    "density_randoms = ds.get_density_mesh(smooth_radius=smooth_radius, cellsize=cellsize, sampling='randoms')\n",
     "\n",
     "fig, ax = plt.subplots(figsize=(4,4))\n",
     "ax.hist(density_data, bins=200, density=True, alpha=0.8, label='around data')\n",
@@ -335,7 +335,7 @@
     "\n",
     "ds = DensitySplit(data_positions=data_positions, boxsize=boxsize)\n",
     "\n",
-    "density = ds.get_density(smooth_radius=smooth_radius, cellsize=cellsize, sampling_positions=sampling_positions)\n",
+    "density = ds.get_density_mesh(smooth_radius=smooth_radius, cellsize=cellsize, sampling_positions=sampling_positions)\n",
     "\n",
     "fig, ax = plt.subplots(figsize=(4,4))\n",
     "ax.hist(density, bins=200, density=True, alpha=0.8)\n",

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
     author='Enrique Paillas',
         author_email='enrique.paillas@uwaterloo.ca',
     packages=find_packages(),
+    package_data={'': ['*.jl']},
     include_package_data=True,
     python_requires='>=3.6, <4',
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ import pathlib
 setup(
     name='densitysplit',
     version='0.0.1',
-    description='icharacterization of density-dependent galaxy clustering',
+    description='characterization of density-dependent galaxy clustering',
     url='https://github.com/epaillas/densitysplit', 
     author='Enrique Paillas',
         author_email='enrique.paillas@uwaterloo.ca',


### PR DESCRIPTION
I started using the density estimation routines for my project, and fixed a few issues I found:
- including the Julia script with the package installation (by default, it was not found);
- the example notebook used `get_density` which apparently was renamed to `get_density_mesh` at some point;
- the default Fourier-space filter shape for `get_density_mesh` should be `TopHat` and not `Tophat`.